### PR TITLE
Follow up theme update

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,27 +20,27 @@ pygmentsStyle = "pygments"
 # See https://feathericons.com/
 # The value of pre is the icon name
 [menu]
-  [[menu.main]]
+  [[menu.nav]]
     name = "Home"
     pre = "home"
     url = "/"
     weight = 1
-  [[menu.main]]
+  [[menu.nav]]
     name = "Blog"
     pre = "edit"
     url = "/post/"
     weight = 2
-  [[menu.main]]
+  [[menu.nav]]
     name = "About"
     pre = "smile"
     url = "/about/"
     weight = 3
-  [[menu.main]]
+  [[menu.nav]]
     name = "Tags"
     pre = "tag"
     url = "/tags/"
     weight = 4
-  [[menu.main]]
+  [[menu.nav]]
     name = "RSS"
     pre = "rss"
     url = "/index.xml"


### PR DESCRIPTION
submodule update したら navbar が現れなくなった問題に対処した。

- `menu.main` という名前だったのが `main.nav` に変更された。
    - `.Site.Menus.nav` という名前で `partials/nav.html` から参照されていたので判明